### PR TITLE
upgrade crop module dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,14 +86,6 @@
     "drupal/webform_views": "5.*"
   },
   "extra": {
-    "installer-paths": {
-      "docroot/modules/contrib/{$name}": [
-        "type:drupal-module"
-      ],
-      "docroot/themes/contrib/{$name}": [
-        "type:drupal-theme"
-      ]
-    },
     "patches": {
       "drupal/core": {
         "Fix broken ckeditor style dropdowns for Objects": "https://www.drupal.org/files/issues/fix_ckeditor_styles_dropdown-2911749-17.patch",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "drupal/block_style_plugins": "1.*",
     "drupal/ckwordcount": "1.*",
     "drupal/config_update": "1.*",
-    "drupal/crop": "2.*",
+    "drupal/crop": "^1.4",
     "drupal/ctools": "3.*",
     "drupal/default_content": "1.*",
     "drupal/editor_file": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "drupal/block_style_plugins": "1.*",
     "drupal/ckwordcount": "1.*",
     "drupal/config_update": "1.*",
-    "drupal/crop": "^1.4",
+    "drupal/crop": "^2.0",
     "drupal/ctools": "3.*",
     "drupal/default_content": "1.*",
     "drupal/editor_file": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "drupal/block_style_plugins": "1.*",
     "drupal/ckwordcount": "1.*",
     "drupal/config_update": "1.*",
-    "drupal/crop": "1.*",
+    "drupal/crop": "2.*",
     "drupal/ctools": "3.*",
     "drupal/default_content": "1.*",
     "drupal/editor_file": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,6 @@
   "extra": {
     "patches": {
       "drupal/core": {
-        "Fix broken ckeditor style dropdowns for Objects": "https://www.drupal.org/files/issues/fix_ckeditor_styles_dropdown-2911749-17.patch",
         "datetime-range views enhancements": "https://www.drupal.org/files/issues/the_views_integration-2786577-202.patch",
         "Drupalimage calling drupallink functions without checking if the plugin is loaded #13": "https://www.drupal.org/files/issues/edit_drupalimage-2855521-13.patch"
       },

--- a/composer.json
+++ b/composer.json
@@ -90,12 +90,7 @@
       "drupal/core": {
         "Fix broken ckeditor style dropdowns for Objects": "https://www.drupal.org/files/issues/fix_ckeditor_styles_dropdown-2911749-17.patch",
         "datetime-range views enhancements": "https://www.drupal.org/files/issues/the_views_integration-2786577-202.patch",
-        "Profile Inheritance": "https://www.drupal.org/files/issues/1356276-408--8.4.x.patch",
-        "multiple image upload dimension fix": "https://www.drupal.org/files/issues/multiple_upload_at_once-2644468-66.patch",
         "Drupalimage calling drupallink functions without checking if the plugin is loaded #13": "https://www.drupal.org/files/issues/edit_drupalimage-2855521-13.patch"
-      },
-      "drupal/photoswipe": {
-        "php error: Render context is empty": "https://www.drupal.org/files/issues/render_context_empty-2824022-4.patch"
       },
       "drupal/url_embed": {
         "make embeds responsive": "https://www.drupal.org/files/issues/option-to-make-embeds-responsive-2825602-2.patch"

--- a/composer.json
+++ b/composer.json
@@ -87,10 +87,10 @@
   },
   "extra": {
     "installer-paths": {
-      "modules/contrib/{$name}": [
+      "docroot/modules/contrib/{$name}": [
         "type:drupal-module"
       ],
-      "themes/contrib/{$name}": [
+      "docroot/themes/contrib/{$name}": [
         "type:drupal-theme"
       ]
     },

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "drupal/block_style_plugins": "1.*",
     "drupal/ckwordcount": "1.*",
     "drupal/config_update": "1.*",
-    "drupal/crop": "2.*",
+    "drupal/crop": "1.*",
     "drupal/ctools": "3.*",
     "drupal/default_content": "1.*",
     "drupal/editor_file": "1.*",


### PR DESCRIPTION
Hi,

We'd like to upgrade to the latest version of Crop in the 8.x-2.x branch, this will allow us to provide the Sitefarm profile alongside Acquia Lightning profile in our environment.

Currently, we're running into a dependency conflict with Crop module, so this should fix this.

Thanks!